### PR TITLE
Improvements to affinity and error handling

### DIFF
--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/BigtableTest.cs
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/BigtableTest.cs
@@ -102,7 +102,9 @@ namespace Grpc.Gcp.IntegrationTest
             var channelRefs = invoker.GetChannelRefsForTest();
             Assert.AreEqual(1, channelRefs.Count);
             Assert.AreEqual(1, channelRefs[0].ActiveStreamCount);
+
             MutateRowResponse response = call.ResponseAsync.Result;
+            channelRefs = invoker.GetChannelRefsForTest();
             Assert.AreEqual(0, channelRefs[0].ActiveStreamCount);
         }
 

--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/LocalServiceTest.cs
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/LocalServiceTest.cs
@@ -1,6 +1,7 @@
 ﻿using Grpc.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -12,27 +13,47 @@ namespace Grpc.Gcp.IntegrationTest
         [TestMethod]
         public async Task ExceptionPropagation()
         {
+            await RunWithServer(
+                new ThrowingService(),
+                null,
+                async (invoker, client) => await Assert.ThrowsExceptionAsync<RpcException>(async () => await client.DoSimpleAsync(new SimpleRequest())),
+                (invoker, client) => Assert.ThrowsException<RpcException>(() => client.DoSimple(new SimpleRequest())));
+        }
+
+        /// <summary>
+        /// Starts up a service, creates a call invoker and a client, using an optional API config,
+        /// then executes the asynchronous and/or synchronous test methods provided.
+        /// </summary>
+        private static async Task RunWithServer(
+            TestService.TestServiceBase serviceImpl,
+            ApiConfig apiConfig,
+            Func<GcpCallInvoker, TestService.TestServiceClient, Task> asyncTestAction,
+            Action<GcpCallInvoker, TestService.TestServiceClient> testAction)
+        {
             var server = new Server
             {
-                Services = { TestService.BindService(new ThrowingService()) },
+                Services = { TestService.BindService(serviceImpl) },
                 Ports = { new ServerPort("localhost", 0, ServerCredentials.Insecure) }
             };
             server.Start();
             try
             {
                 var port = server.Ports.First();
-                var invoker = new GcpCallInvoker(port.Host, port.BoundPort, ChannelCredentials.Insecure);
-
+                var options = new List<ChannelOption>();
+                if (apiConfig != null)
+                {
+                    options.Add(new ChannelOption(GcpCallInvoker.ApiConfigChannelArg, apiConfig.ToString()));
+                }
+                var invoker = new GcpCallInvoker(port.Host, port.BoundPort, ChannelCredentials.Insecure, options);
                 var client = new TestService.TestServiceClient(invoker);
-
-                await Assert.ThrowsExceptionAsync<RpcException>(async () => await client.DoSimpleAsync(new SimpleRequest()));
+                await (asyncTestAction?.Invoke(invoker, client) ?? Task.FromResult(0));
+                testAction?.Invoke(invoker, client);
             }
             finally
             {
                 await server.ShutdownAsync();
             }
         }
-
 
         private class ThrowingService : TestService.TestServiceBase
         {

--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/TestService.cs
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/TestService.cs
@@ -26,15 +26,27 @@ namespace Grpc.Gcp.IntegrationTest {
           string.Concat(
             "ChJ0ZXN0X3NlcnZpY2UucHJvdG8SGWdycGMuZ2NwLmludGVncmF0aW9uX3Rl",
             "c3QiHQoNU2ltcGxlUmVxdWVzdBIMCgRuYW1lGAEgASgJIh4KDlNpbXBsZVJl",
-            "c3BvbnNlEgwKBG5hbWUYAiABKAkybgoLVGVzdFNlcnZpY2USXwoIRG9TaW1w",
-            "bGUSKC5ncnBjLmdjcC5pbnRlZ3JhdGlvbl90ZXN0LlNpbXBsZVJlcXVlc3Qa",
-            "KS5ncnBjLmdjcC5pbnRlZ3JhdGlvbl90ZXN0LlNpbXBsZVJlc3BvbnNlYgZw",
-            "cm90bzM="));
+            "c3BvbnNlEgwKBG5hbWUYAiABKAkiawoMQ29tcGxleElubmVyEgwKBG5hbWUY",
+            "ASABKAkSDgoGbnVtYmVyGAIgASgFEj0KDG5lc3RlZF9pbm5lchgDIAEoCzIn",
+            "LmdycGMuZ2NwLmludGVncmF0aW9uX3Rlc3QuQ29tcGxleElubmVyImYKDkNv",
+            "bXBsZXhSZXF1ZXN0EgwKBG5hbWUYASABKAkSDgoGbnVtYmVyGAIgASgFEjYK",
+            "BWlubmVyGAMgASgLMicuZ3JwYy5nY3AuaW50ZWdyYXRpb25fdGVzdC5Db21w",
+            "bGV4SW5uZXIiZwoPQ29tcGxleFJlc3BvbnNlEgwKBG5hbWUYASABKAkSDgoG",
+            "bnVtYmVyGAIgASgFEjYKBWlubmVyGAMgASgLMicuZ3JwYy5nY3AuaW50ZWdy",
+            "YXRpb25fdGVzdC5Db21wbGV4SW5uZXIy0gEKC1Rlc3RTZXJ2aWNlEl8KCERv",
+            "U2ltcGxlEiguZ3JwYy5nY3AuaW50ZWdyYXRpb25fdGVzdC5TaW1wbGVSZXF1",
+            "ZXN0GikuZ3JwYy5nY3AuaW50ZWdyYXRpb25fdGVzdC5TaW1wbGVSZXNwb25z",
+            "ZRJiCglEb0NvbXBsZXgSKS5ncnBjLmdjcC5pbnRlZ3JhdGlvbl90ZXN0LkNv",
+            "bXBsZXhSZXF1ZXN0GiouZ3JwYy5nY3AuaW50ZWdyYXRpb25fdGVzdC5Db21w",
+            "bGV4UmVzcG9uc2ViBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.SimpleRequest), global::Grpc.Gcp.IntegrationTest.SimpleRequest.Parser, new[]{ "Name" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.SimpleResponse), global::Grpc.Gcp.IntegrationTest.SimpleResponse.Parser, new[]{ "Name" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.SimpleResponse), global::Grpc.Gcp.IntegrationTest.SimpleResponse.Parser, new[]{ "Name" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.ComplexInner), global::Grpc.Gcp.IntegrationTest.ComplexInner.Parser, new[]{ "Name", "Number", "NestedInner" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.ComplexRequest), global::Grpc.Gcp.IntegrationTest.ComplexRequest.Parser, new[]{ "Name", "Number", "Inner" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Grpc.Gcp.IntegrationTest.ComplexResponse), global::Grpc.Gcp.IntegrationTest.ComplexResponse.Parser, new[]{ "Name", "Number", "Inner" }, null, null, null)
           }));
     }
     #endregion
@@ -291,6 +303,579 @@ namespace Grpc.Gcp.IntegrationTest {
             break;
           case 18: {
             Name = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class ComplexInner : pb::IMessage<ComplexInner> {
+    private static readonly pb::MessageParser<ComplexInner> _parser = new pb::MessageParser<ComplexInner>(() => new ComplexInner());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ComplexInner> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Grpc.Gcp.IntegrationTest.TestServiceReflection.Descriptor.MessageTypes[2]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexInner() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexInner(ComplexInner other) : this() {
+      name_ = other.name_;
+      number_ = other.number_;
+      NestedInner = other.nestedInner_ != null ? other.NestedInner.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexInner Clone() {
+      return new ComplexInner(this);
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 1;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "number" field.</summary>
+    public const int NumberFieldNumber = 2;
+    private int number_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int Number {
+      get { return number_; }
+      set {
+        number_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "nested_inner" field.</summary>
+    public const int NestedInnerFieldNumber = 3;
+    private global::Grpc.Gcp.IntegrationTest.ComplexInner nestedInner_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Grpc.Gcp.IntegrationTest.ComplexInner NestedInner {
+      get { return nestedInner_; }
+      set {
+        nestedInner_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ComplexInner);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ComplexInner other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Name != other.Name) return false;
+      if (Number != other.Number) return false;
+      if (!object.Equals(NestedInner, other.NestedInner)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (Number != 0) hash ^= Number.GetHashCode();
+      if (nestedInner_ != null) hash ^= NestedInner.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
+      if (Number != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Number);
+      }
+      if (nestedInner_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(NestedInner);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (Number != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Number);
+      }
+      if (nestedInner_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(NestedInner);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ComplexInner other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.Number != 0) {
+        Number = other.Number;
+      }
+      if (other.nestedInner_ != null) {
+        if (nestedInner_ == null) {
+          nestedInner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+        }
+        NestedInner.MergeFrom(other.NestedInner);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
+          case 16: {
+            Number = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            if (nestedInner_ == null) {
+              nestedInner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+            }
+            input.ReadMessage(nestedInner_);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class ComplexRequest : pb::IMessage<ComplexRequest> {
+    private static readonly pb::MessageParser<ComplexRequest> _parser = new pb::MessageParser<ComplexRequest>(() => new ComplexRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ComplexRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Grpc.Gcp.IntegrationTest.TestServiceReflection.Descriptor.MessageTypes[3]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexRequest(ComplexRequest other) : this() {
+      name_ = other.name_;
+      number_ = other.number_;
+      Inner = other.inner_ != null ? other.Inner.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexRequest Clone() {
+      return new ComplexRequest(this);
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 1;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "number" field.</summary>
+    public const int NumberFieldNumber = 2;
+    private int number_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int Number {
+      get { return number_; }
+      set {
+        number_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "inner" field.</summary>
+    public const int InnerFieldNumber = 3;
+    private global::Grpc.Gcp.IntegrationTest.ComplexInner inner_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Grpc.Gcp.IntegrationTest.ComplexInner Inner {
+      get { return inner_; }
+      set {
+        inner_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ComplexRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ComplexRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Name != other.Name) return false;
+      if (Number != other.Number) return false;
+      if (!object.Equals(Inner, other.Inner)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (Number != 0) hash ^= Number.GetHashCode();
+      if (inner_ != null) hash ^= Inner.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
+      if (Number != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Number);
+      }
+      if (inner_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(Inner);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (Number != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Number);
+      }
+      if (inner_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Inner);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ComplexRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.Number != 0) {
+        Number = other.Number;
+      }
+      if (other.inner_ != null) {
+        if (inner_ == null) {
+          inner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+        }
+        Inner.MergeFrom(other.Inner);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
+          case 16: {
+            Number = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            if (inner_ == null) {
+              inner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+            }
+            input.ReadMessage(inner_);
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class ComplexResponse : pb::IMessage<ComplexResponse> {
+    private static readonly pb::MessageParser<ComplexResponse> _parser = new pb::MessageParser<ComplexResponse>(() => new ComplexResponse());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ComplexResponse> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Grpc.Gcp.IntegrationTest.TestServiceReflection.Descriptor.MessageTypes[4]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexResponse() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexResponse(ComplexResponse other) : this() {
+      name_ = other.name_;
+      number_ = other.number_;
+      Inner = other.inner_ != null ? other.Inner.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ComplexResponse Clone() {
+      return new ComplexResponse(this);
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 1;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "number" field.</summary>
+    public const int NumberFieldNumber = 2;
+    private int number_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int Number {
+      get { return number_; }
+      set {
+        number_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "inner" field.</summary>
+    public const int InnerFieldNumber = 3;
+    private global::Grpc.Gcp.IntegrationTest.ComplexInner inner_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Grpc.Gcp.IntegrationTest.ComplexInner Inner {
+      get { return inner_; }
+      set {
+        inner_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ComplexResponse);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ComplexResponse other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Name != other.Name) return false;
+      if (Number != other.Number) return false;
+      if (!object.Equals(Inner, other.Inner)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (Number != 0) hash ^= Number.GetHashCode();
+      if (inner_ != null) hash ^= Inner.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (Name.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Name);
+      }
+      if (Number != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Number);
+      }
+      if (inner_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(Inner);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (Number != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Number);
+      }
+      if (inner_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Inner);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ComplexResponse other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.Number != 0) {
+        Number = other.Number;
+      }
+      if (other.inner_ != null) {
+        if (inner_ == null) {
+          inner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+        }
+        Inner.MergeFrom(other.Inner);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Name = input.ReadString();
+            break;
+          }
+          case 16: {
+            Number = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            if (inner_ == null) {
+              inner_ = new global::Grpc.Gcp.IntegrationTest.ComplexInner();
+            }
+            input.ReadMessage(inner_);
             break;
           }
         }

--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/TestServiceGrpc.cs
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/TestServiceGrpc.cs
@@ -4,7 +4,7 @@
 // </auto-generated>
 // Original file comments:
 //
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
@@ -21,6 +21,8 @@ namespace Grpc.Gcp.IntegrationTest {
 
     static readonly grpc::Marshaller<global::Grpc.Gcp.IntegrationTest.SimpleRequest> __Marshaller_SimpleRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Grpc.Gcp.IntegrationTest.SimpleRequest.Parser.ParseFrom);
     static readonly grpc::Marshaller<global::Grpc.Gcp.IntegrationTest.SimpleResponse> __Marshaller_SimpleResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Grpc.Gcp.IntegrationTest.SimpleResponse.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Grpc.Gcp.IntegrationTest.ComplexRequest> __Marshaller_ComplexRequest = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Grpc.Gcp.IntegrationTest.ComplexRequest.Parser.ParseFrom);
+    static readonly grpc::Marshaller<global::Grpc.Gcp.IntegrationTest.ComplexResponse> __Marshaller_ComplexResponse = grpc::Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Grpc.Gcp.IntegrationTest.ComplexResponse.Parser.ParseFrom);
 
     static readonly grpc::Method<global::Grpc.Gcp.IntegrationTest.SimpleRequest, global::Grpc.Gcp.IntegrationTest.SimpleResponse> __Method_DoSimple = new grpc::Method<global::Grpc.Gcp.IntegrationTest.SimpleRequest, global::Grpc.Gcp.IntegrationTest.SimpleResponse>(
         grpc::MethodType.Unary,
@@ -28,6 +30,13 @@ namespace Grpc.Gcp.IntegrationTest {
         "DoSimple",
         __Marshaller_SimpleRequest,
         __Marshaller_SimpleResponse);
+
+    static readonly grpc::Method<global::Grpc.Gcp.IntegrationTest.ComplexRequest, global::Grpc.Gcp.IntegrationTest.ComplexResponse> __Method_DoComplex = new grpc::Method<global::Grpc.Gcp.IntegrationTest.ComplexRequest, global::Grpc.Gcp.IntegrationTest.ComplexResponse>(
+        grpc::MethodType.Unary,
+        __ServiceName,
+        "DoComplex",
+        __Marshaller_ComplexRequest,
+        __Marshaller_ComplexResponse);
 
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
@@ -39,6 +48,11 @@ namespace Grpc.Gcp.IntegrationTest {
     public abstract partial class TestServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Grpc.Gcp.IntegrationTest.SimpleResponse> DoSimple(global::Grpc.Gcp.IntegrationTest.SimpleRequest request, grpc::ServerCallContext context)
+      {
+        throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
+      }
+
+      public virtual global::System.Threading.Tasks.Task<global::Grpc.Gcp.IntegrationTest.ComplexResponse> DoComplex(global::Grpc.Gcp.IntegrationTest.ComplexRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -84,6 +98,22 @@ namespace Grpc.Gcp.IntegrationTest {
       {
         return CallInvoker.AsyncUnaryCall(__Method_DoSimple, null, options, request);
       }
+      public virtual global::Grpc.Gcp.IntegrationTest.ComplexResponse DoComplex(global::Grpc.Gcp.IntegrationTest.ComplexRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return DoComplex(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual global::Grpc.Gcp.IntegrationTest.ComplexResponse DoComplex(global::Grpc.Gcp.IntegrationTest.ComplexRequest request, grpc::CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_DoComplex, null, options, request);
+      }
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Gcp.IntegrationTest.ComplexResponse> DoComplexAsync(global::Grpc.Gcp.IntegrationTest.ComplexRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return DoComplexAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Gcp.IntegrationTest.ComplexResponse> DoComplexAsync(global::Grpc.Gcp.IntegrationTest.ComplexRequest request, grpc::CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_DoComplex, null, options, request);
+      }
       /// <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
       protected override TestServiceClient NewInstance(ClientBaseConfiguration configuration)
       {
@@ -96,7 +126,8 @@ namespace Grpc.Gcp.IntegrationTest {
     public static grpc::ServerServiceDefinition BindService(TestServiceBase serviceImpl)
     {
       return grpc::ServerServiceDefinition.CreateBuilder()
-          .AddMethod(__Method_DoSimple, serviceImpl.DoSimple).Build();
+          .AddMethod(__Method_DoSimple, serviceImpl.DoSimple)
+          .AddMethod(__Method_DoComplex, serviceImpl.DoComplex).Build();
     }
 
   }

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
@@ -25,10 +25,10 @@ namespace Grpc.Gcp
         internal int AffinityCount => Interlocked.CompareExchange(ref affinityCount, 0, 0);
         internal int ActiveStreamCount => Interlocked.CompareExchange(ref activeStreamCount, 0, 0);
 
-        internal void AffinityCountIncr() => Interlocked.Increment(ref affinityCount);
-        internal void AffinityCountDecr() => Interlocked.Decrement(ref affinityCount);
-        internal void ActiveStreamCountIncr() => Interlocked.Increment(ref activeStreamCount);
-        internal void ActiveStreamCountDecr() => Interlocked.Decrement(ref activeStreamCount);
+        internal int AffinityCountIncr() => Interlocked.Increment(ref affinityCount);
+        internal int AffinityCountDecr() => Interlocked.Decrement(ref affinityCount);
+        internal int ActiveStreamCountIncr() => Interlocked.Increment(ref activeStreamCount);
+        internal int ActiveStreamCountDecr() => Interlocked.Decrement(ref activeStreamCount);
 
         internal ChannelRef Clone() => new ChannelRef(Channel, id, AffinityCount, ActiveStreamCount);
     }

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -219,8 +219,13 @@ namespace Grpc.Gcp
                 {
                     if (channelRefByAffinityKey.TryGetValue(affinityKey, out ChannelRef channelRef))
                     {
-                        channelRef.AffinityCountDecr();
-                        channelRefByAffinityKey.Remove(affinityKey);
+                        int newCount = channelRef.AffinityCountDecr();
+
+                        // We would expect it to be exactly 0, but it doesn't hurt to be cautious.
+                        if (newCount <= 0)
+                        {
+                            channelRefByAffinityKey.Remove(affinityKey);
+                        }
                     }
                 }
             }

--- a/protos/test_service.proto
+++ b/protos/test_service.proto
@@ -11,6 +11,7 @@ package grpc.gcp.integration_test;
 
 service TestService {
   rpc DoSimple(SimpleRequest) returns (SimpleResponse);
+  rpc DoComplex(ComplexRequest) returns (ComplexResponse);
 }
 
 message SimpleRequest {
@@ -19,4 +20,22 @@ message SimpleRequest {
 
 message SimpleResponse {
   string name = 2;
+}
+
+message ComplexInner {
+  string name = 1;
+  int32 number = 2;
+  ComplexInner nested_inner = 3;
+}
+
+message ComplexRequest {
+  string name = 1;
+  int32 number = 2;
+  ComplexInner inner = 3;
+}
+
+message ComplexResponse {
+  string name = 1;
+  int32 number = 2;
+  ComplexInner inner = 3;
 }


### PR DESCRIPTION
Fixes #19 and #16.

I can split these up into separate PRs if you want, but the commits are already separated fairly readably.

I haven't run the Spanner and Bigtable integration tests, as they'd require authentication for the appropriate GCP project. It might be worth refactoring most of those tests to be tests against a local service instead.