### PR TITLE
DO NOT MERGE: try adapting Grpc.Gcp to work on top of grpc-dotnet

### DIFF
--- a/Grpc.Gcp/Common.csproj.include
+++ b/Grpc.Gcp/Common.csproj.include
@@ -1,9 +1,0 @@
-<!-- Common definitions shared by all .csproj files -->
-<Project>
-  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <!-- Workaround for https://github.com/dotnet/sdk/issues/335 -->
-    <FrameworkPathOverride Condition="Exists('/usr/lib/mono/4.5-api')">/usr/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/usr/local/lib/mono/4.5-api')">/usr/local/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api')">/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api</FrameworkPathOverride>
-  </PropertyGroup>
-</Project>

--- a/Grpc.Gcp/Grpc.Gcp.Benchmark/Grpc.Gcp.Benchmark.csproj
+++ b/Grpc.Gcp/Grpc.Gcp.Benchmark/Grpc.Gcp.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/Grpc.Gcp.IntegrationTest.csproj
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/Grpc.Gcp.IntegrationTest.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
-    <!--<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../keys/Grpc.Gcp.snk</AssemblyOriginatorKeyFile>

--- a/Grpc.Gcp/Grpc.Gcp.IntegrationTest/Grpc.Gcp.IntegrationTest.csproj
+++ b/Grpc.Gcp/Grpc.Gcp.IntegrationTest/Grpc.Gcp.IntegrationTest.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\Common.csproj.include" />
-
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <!--<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>-->
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../keys/Grpc.Gcp.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,18 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grpc.Gcp\Grpc.Gcp.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>mscorlib</HintPath>
-    </Reference>
-    <Reference Include="System">
-      <HintPath>System</HintPath>
-    </Reference>
-    <Reference Include="System.Core">
-      <HintPath>System.Core</HintPath>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
@@ -13,7 +13,7 @@ namespace Grpc.Gcp
         private int activeStreamCount;
         private int id;
 
-        public ChannelRef(Channel channel, int id, int affinityCount = 0, int activeStreamCount = 0)
+        public ChannelRef(ChannelBase channel, int id, int affinityCount = 0, int activeStreamCount = 0)
         {
             Channel = channel;
             CallInvoker = channel.CreateCallInvoker();
@@ -22,7 +22,7 @@ namespace Grpc.Gcp
             this.activeStreamCount = activeStreamCount;
         }
 
-        internal Channel Channel { get; }
+        internal ChannelBase Channel { get; }
         internal CallInvoker CallInvoker { get; }
         internal int AffinityCount => Interlocked.CompareExchange(ref affinityCount, 0, 0);
         internal int ActiveStreamCount => Interlocked.CompareExchange(ref activeStreamCount, 0, 0);

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRef.cs
@@ -16,12 +16,14 @@ namespace Grpc.Gcp
         public ChannelRef(Channel channel, int id, int affinityCount = 0, int activeStreamCount = 0)
         {
             Channel = channel;
+            CallInvoker = channel.CreateCallInvoker();
             this.id = id;
             this.affinityCount = affinityCount;
             this.activeStreamCount = activeStreamCount;
         }
 
         internal Channel Channel { get; }
+        internal CallInvoker CallInvoker { get; }
         internal int AffinityCount => Interlocked.CompareExchange(ref affinityCount, 0, 0);
         internal int ActiveStreamCount => Interlocked.CompareExchange(ref activeStreamCount, 0, 0);
 

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
@@ -9,9 +9,9 @@ namespace Grpc.Gcp
     /// <summary>
     /// Encapsulates creation of new channels.
     /// </summary>
-    internal abstract class ChannelRefFactory
+    public abstract class ChannelRefFactory
     {
-        public virtual ChannelRef CreateChannelRef(int id)
+        internal virtual ChannelRef CreateChannelRef(int id)
         {
             throw new NotImplementedException();
         }

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
@@ -2,39 +2,18 @@
 using System.Threading;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Grpc.Gcp
 {
     /// <summary>
     /// Encapsulates creation of new channels.
     /// </summary>
-    internal sealed class ChannelRefFactory
+    internal abstract class ChannelRefFactory
     {
-        private const string ClientChannelId = "grpc_gcp.client_channel.id";
-        // TODO: in theory the counter can overflow
-        private static int clientChannelIdCounter = 0;
-
-        private readonly string target;
-        private readonly ChannelCredentials credentials;
-        private readonly IEnumerable<ChannelOption> channelOptions;
-
-        public ChannelRefFactory(string target, ChannelCredentials credentials, IEnumerable<ChannelOption> channelOptions)
+        public virtual ChannelRef CreateChannelRef(int id)
         {
-            this.target = target;
-            this.credentials = credentials;
-            this.channelOptions = channelOptions;
-        }
-
-        public ChannelRef CreateChannelRef(int id)
-        {
-            // Creates a new gRPC channel.
-            GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");
-
-            // TODO: clientChannelIdCounter is independent of ID and is basically just a unique identifier
-            // TODO: is passing the base options needed?
-            var channel = new Channel(target, credentials,
-                channelOptions.Concat(new[] { new ChannelOption(ClientChannelId, Interlocked.Increment (ref clientChannelIdCounter)) }));
-            return new ChannelRef(channel, id);
+            throw new NotImplementedException();
         }
     }
 }

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactory.cs
@@ -1,0 +1,40 @@
+﻿using Grpc.Core;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Grpc.Gcp
+{
+    /// <summary>
+    /// Encapsulates creation of new channels.
+    /// </summary>
+    internal sealed class ChannelRefFactory
+    {
+        private const string ClientChannelId = "grpc_gcp.client_channel.id";
+        // TODO: in theory the counter can overflow
+        private static int clientChannelIdCounter = 0;
+
+        private readonly string target;
+        private readonly ChannelCredentials credentials;
+        private readonly IEnumerable<ChannelOption> channelOptions;
+
+        public ChannelRefFactory(string target, ChannelCredentials credentials, IEnumerable<ChannelOption> channelOptions)
+        {
+            this.target = target;
+            this.credentials = credentials;
+            this.channelOptions = channelOptions;
+        }
+
+        public ChannelRef CreateChannelRef(int id)
+        {
+            // Creates a new gRPC channel.
+            GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");
+
+            // TODO: clientChannelIdCounter is independent of ID and is basically just a unique identifier
+            // TODO: is passing the base options needed?
+            var channel = new Channel(target, credentials,
+                channelOptions.Concat(new[] { new ChannelOption(ClientChannelId, Interlocked.Increment (ref clientChannelIdCounter)) }));
+            return new ChannelRef(channel, id);
+        }
+    }
+}

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcCore.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcCore.cs
@@ -8,7 +8,7 @@ namespace Grpc.Gcp
     // /// <summary>
     // /// Encapsulates creation of new channels.
     // /// </summary>
-    // internal sealed class ChannelRefFactoryGrpcCore : ChannelRefFactory
+    // public sealed class ChannelRefFactoryGrpcCore : ChannelRefFactory
     // {
     //     private const string ClientChannelId = "grpc_gcp.client_channel.id";
     //     // TODO: in theory the counter can overflow
@@ -25,7 +25,7 @@ namespace Grpc.Gcp
     //         this.channelOptions = channelOptions;
     //     }
 
-    //     public override ChannelRef CreateChannelRef(int id)
+    //     internal override ChannelRef CreateChannelRef(int id)
     //     {
     //         // Creates a new gRPC channel.
     //         GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcCore.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcCore.cs
@@ -1,0 +1,40 @@
+﻿using Grpc.Core;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Grpc.Gcp
+{
+    // /// <summary>
+    // /// Encapsulates creation of new channels.
+    // /// </summary>
+    // internal sealed class ChannelRefFactoryGrpcCore : ChannelRefFactory
+    // {
+    //     private const string ClientChannelId = "grpc_gcp.client_channel.id";
+    //     // TODO: in theory the counter can overflow
+    //     private static int clientChannelIdCounter = 0;
+
+    //     private readonly string target;
+    //     private readonly ChannelCredentials credentials;
+    //     private readonly IEnumerable<ChannelOption> channelOptions;
+
+    //     public ChannelRefFactoryGrpcCore(string target, ChannelCredentials credentials, IEnumerable<ChannelOption> channelOptions)
+    //     {
+    //         this.target = target;
+    //         this.credentials = credentials;
+    //         this.channelOptions = channelOptions;
+    //     }
+
+    //     public override ChannelRef CreateChannelRef(int id)
+    //     {
+    //         // Creates a new gRPC channel.
+    //         GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");
+
+    //         // TODO: clientChannelIdCounter is independent of ID and is basically just a unique identifier
+    //         // TODO: is passing the base options needed?
+    //         var channel = new Channel(target, credentials,
+    //             channelOptions.Concat(new[] { new ChannelOption(ClientChannelId, Interlocked.Increment (ref clientChannelIdCounter)) }));
+    //         return new ChannelRef(channel, id);
+    //     }
+    // }
+}

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcDotnet.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcDotnet.cs
@@ -1,0 +1,32 @@
+﻿using Grpc.Core;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+using Grpc.Net.Client;
+
+namespace Grpc.Gcp
+{
+    /// <summary>
+    /// Encapsulates creation of new channels.
+    /// </summary>
+    internal sealed class ChannelRefFactoryGrpcDotnet : ChannelRefFactory
+    {
+        private readonly string target;
+
+        public ChannelRefFactoryGrpcDotnet(string target)
+        {
+            this.target = target;
+        }
+
+        public override ChannelRef CreateChannelRef(int id)
+        {
+            // TODO: add a message to log
+            //GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");
+            
+            // TODO: always use a separate httphandler, so that separate connection is guaranteed.
+            // TODO: allow setting GrpcChannelOptions (grpc-dotnet specific channel configuration)
+            var channel = GrpcChannel.ForAddress(target);
+            return new ChannelRef(channel, id);
+        }
+    }
+}

--- a/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcDotnet.cs
+++ b/Grpc.Gcp/Grpc.Gcp/ChannelRefFactoryGrpcDotnet.cs
@@ -9,7 +9,7 @@ namespace Grpc.Gcp
     /// <summary>
     /// Encapsulates creation of new channels.
     /// </summary>
-    internal sealed class ChannelRefFactoryGrpcDotnet : ChannelRefFactory
+    public sealed class ChannelRefFactoryGrpcDotnet : ChannelRefFactory
     {
         private readonly string target;
 
@@ -18,7 +18,7 @@ namespace Grpc.Gcp
             this.target = target;
         }
 
-        public override ChannelRef CreateChannelRef(int id)
+        internal override ChannelRef CreateChannelRef(int id)
         {
             // TODO: add a message to log
             //GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -10,8 +10,7 @@ using System.Threading.Tasks;
 namespace Grpc.Gcp
 {
     /// <summary>
-    /// Invokes client RPCs using <see cref="Calls"/>.
-    /// Calls are made through underlying gcp channel pool.
+    /// Invokes client RPCs using an underlying channel pool.
     /// </summary>
     public class GcpCallInvoker : CallInvoker
     {

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -50,7 +50,7 @@ namespace Grpc.Gcp
         /// </summary>
         /// <param name="channleRefFactory">Target of the underlying grpc channels.</param>
         /// <param name="apiConfig">API config represented as a JSON string.</param>
-        internal GcpCallInvoker(ChannelRefFactory channelRefFactory, string apiConfigJson)
+        public GcpCallInvoker(ChannelRefFactory channelRefFactory, string apiConfigJson)
         {
             // TODO: check channelRefFactory not null
             this.channelRefFactory = channelRefFactory;

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -29,32 +29,45 @@ namespace Grpc.Gcp
         private readonly ApiConfig apiConfig;
         private readonly IDictionary<string, AffinityConfig> affinityByMethod;
 
+        // /// <summary>
+        // /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
+        // /// </summary>
+        // /// <param name="target">Target of the underlying grpc channels.</param>
+        // /// <param name="credentials">Credentials to secure the underlying grpc channels.</param>
+        // /// <param name="options">Channel options to be used by the underlying grpc channels.</param>
+        // public GcpCallInvoker(string target, ChannelCredentials credentials, IEnumerable<ChannelOption> options = null)
+        // {
+        //     this.apiConfig = CreateApiConfigFromChannelOptionsOrDefault(options);
+        //     this.affinityByMethod = CreateAffinityByMethodIndex(this.apiConfig);
+
+        //     // options other than ApiConfigChannelArg
+        //     var otherOptions = options != null ? options.Where(o => o.Name != ApiConfigChannelArg).ToList() : new List<ChannelOption>();
+        //     this.channelRefFactory = new ChannelRefFactory(target, credentials, otherOptions);
+        // }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
         /// </summary>
-        /// <param name="target">Target of the underlying grpc channels.</param>
-        /// <param name="credentials">Credentials to secure the underlying grpc channels.</param>
-        /// <param name="options">Channel options to be used by the underlying grpc channels.</param>
-        public GcpCallInvoker(string target, ChannelCredentials credentials, IEnumerable<ChannelOption> options = null)
+        /// <param name="channleRefFactory">Target of the underlying grpc channels.</param>
+        /// <param name="apiConfig">API config represented as a JSON string.</param>
+        internal GcpCallInvoker(ChannelRefFactory channelRefFactory, string apiConfigJson)
         {
-            this.apiConfig = CreateApiConfigFromChannelOptionsOrDefault(options);
+            // TODO: check channelRefFactory not null
+            this.channelRefFactory = channelRefFactory;
+            this.apiConfig = CreateApiConfigFromJsonOrDefault(apiConfigJson);
             this.affinityByMethod = CreateAffinityByMethodIndex(this.apiConfig);
-
-            // options other than ApiConfigChannelArg
-            var otherOptions = options != null ? options.Where(o => o.Name != ApiConfigChannelArg).ToList() : new List<ChannelOption>();
-            this.channelRefFactory = new ChannelRefFactory(target, credentials, otherOptions);
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
-        /// </summary>
-        /// <param name="host">Hostname of target.</param>
-        /// <param name="port">Port number of target</param>
-        /// <param name="credentials">Credentials to secure the underlying grpc channels.</param>
-        /// <param name="options">Channel options to be used by the underlying grpc channels.</param>
-        public GcpCallInvoker(string host, int port, ChannelCredentials credentials, IEnumerable<ChannelOption> options = null) :
-            this($"{host}:{port}", credentials, options)
-        { }
+        // /// <summary>
+        // /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
+        // /// </summary>
+        // /// <param name="host">Hostname of target.</param>
+        // /// <param name="port">Port number of target</param>
+        // /// <param name="credentials">Credentials to secure the underlying grpc channels.</param>
+        // /// <param name="options">Channel options to be used by the underlying grpc channels.</param>
+        // public GcpCallInvoker(string host, int port, ChannelCredentials credentials, IEnumerable<ChannelOption> options = null) :
+        //     this($"{host}:{port}", credentials, options)
+        // { }
 
         private static ApiConfig CreateDefaultApiConfig() =>
             new ApiConfig
@@ -66,25 +79,25 @@ namespace Grpc.Gcp
                 }
             };
 
-        private static ApiConfig CreateApiConfigFromChannelOptionsOrDefault(IEnumerable<ChannelOption> options)
-        {
-            var option = options?.FirstOrDefault(opt => opt.Name == ApiConfigChannelArg);
-            if (option == null)
-            {
-                return CreateDefaultApiConfig();
-            }
+        // private static ApiConfig CreateApiConfigFromChannelOptionsOrDefault(IEnumerable<ChannelOption> options)
+        // {
+        //     var option = options?.FirstOrDefault(opt => opt.Name == ApiConfigChannelArg);
+        //     if (option == null)
+        //     {
+        //         return CreateDefaultApiConfig();
+        //     }
 
-            string jsonString;
-            try
-            {
-                jsonString = option.StringValue;
-            }
-            catch (InvalidOperationException ex)
-            {
-                throw new ArgumentException($"Invalid API config: channel option \"{ApiConfigChannelArg}\" must be of type string", ex);
-            }
-            return CreateApiConfigFromJsonOrDefault(jsonString);
-        }
+        //     string jsonString;
+        //     try
+        //     {
+        //         jsonString = option.StringValue;
+        //     }
+        //     catch (InvalidOperationException ex)
+        //     {
+        //         throw new ArgumentException($"Invalid API config: channel option \"{ApiConfigChannelArg}\" must be of type string", ex);
+        //     }
+        //     return CreateApiConfigFromJsonOrDefault(jsonString);
+        // }
 
         private static ApiConfig CreateApiConfigFromJsonOrDefault(string json)
         {

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -311,8 +311,7 @@ namespace Grpc.Gcp
         {
             // No channel affinity feature for client streaming call.
             ChannelRef channelRef = GetChannelRef();
-            var callDetails = new CallInvocationDetails<TRequest, TResponse>(channelRef.Channel, method, host, options);
-            var originalCall = Calls.AsyncClientStreamingCall(callDetails);
+            var originalCall = channelRef.CallInvoker.AsyncClientStreamingCall(method, host, options);
 
             // Decrease the active streams count once async response finishes.
             var gcpResponseAsync = DecrementCountAndPropagateResult(originalCall.ResponseAsync);
@@ -349,8 +348,7 @@ namespace Grpc.Gcp
         {
             // No channel affinity feature for duplex streaming call.
             ChannelRef channelRef = GetChannelRef();
-            var callDetails = new CallInvocationDetails<TRequest, TResponse>(channelRef.Channel, method, host, options);
-            var originalCall = Calls.AsyncDuplexStreamingCall(callDetails);
+            var originalCall = channelRef.CallInvoker.AsyncDuplexStreamingCall(method, host, options);
 
             // Decrease the active streams count once the streaming response finishes its final batch.
             var gcpResponseStream = new GcpClientResponseStream<TRequest, TResponse>(
@@ -378,8 +376,7 @@ namespace Grpc.Gcp
 
             ChannelRef channelRef = PreProcess(affinityConfig, request);
 
-            var callDetails = new CallInvocationDetails<TRequest, TResponse>(channelRef.Channel, method, host, options);
-            var originalCall = Calls.AsyncServerStreamingCall(callDetails, request);
+            var originalCall = channelRef.CallInvoker.AsyncServerStreamingCall(method, host, options, request);
 
             // Executes affinity postprocess once the streaming response finishes its final batch.
             var gcpResponseStream = new GcpClientResponseStream<TRequest, TResponse>(
@@ -406,8 +403,7 @@ namespace Grpc.Gcp
 
             ChannelRef channelRef = PreProcess(affinityConfig, request);
 
-            var callDetails = new CallInvocationDetails<TRequest, TResponse>(channelRef.Channel, method, host, options);
-            var originalCall = Calls.AsyncUnaryCall(callDetails, request);
+            var originalCall = channelRef.CallInvoker.AsyncUnaryCall<TRequest, TResponse>(method, host, options, request);
 
             // Executes affinity postprocess once the async response finishes.
             var gcpResponseAsync = PostProcessPropagateResult(originalCall.ResponseAsync);
@@ -445,11 +441,10 @@ namespace Grpc.Gcp
 
             ChannelRef channelRef = PreProcess(affinityConfig, request);
 
-            var callDetails = new CallInvocationDetails<TRequest, TResponse>(channelRef.Channel, method, host, options);
             TResponse response = default(TResponse);
             try
             {
-                response = Calls.BlockingUnaryCall<TRequest, TResponse>(callDetails, request);
+                response = channelRef.CallInvoker.BlockingUnaryCall<TRequest, TResponse>(method, host, options, request);
                 return response;
             }
             finally

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -173,7 +173,7 @@ namespace Grpc.Gcp
             }
         }
 
-        private List<string> GetAffinityKeysFromProto(string affinityKey, IMessage message)
+        private static List<string> GetAffinityKeysFromProto(string affinityKey, IMessage message)
         {
             List<string> affinityKeyValues = new List<string>();
             if (!string.IsNullOrEmpty(affinityKey))
@@ -184,7 +184,7 @@ namespace Grpc.Gcp
             return affinityKeyValues;
         }
 
-        private void GetAffinityKeysFromProto(string[] names, int namesIndex, IMessage message, List<string> affinityKeyValues)
+        private static void GetAffinityKeysFromProto(string[] names, int namesIndex, IMessage message, List<string> affinityKeyValues)
         {
             if (namesIndex >= names.Length)
             {

--- a/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
+++ b/Grpc.Gcp/Grpc.Gcp/GcpCallInvoker.cs
@@ -470,6 +470,9 @@ namespace Grpc.Gcp
         {
             for (int i = 0; i < channelRefs.Count; i++)
             {
+                // TODO: it seems that grpc-dotnet doesn't actually override this method (and so for 
+                // grpc-dotnet this is a no-op).
+                // only GrpcChannel.Dispose() actually does something.
                 await channelRefs[i].Channel.ShutdownAsync();
             }
         }

--- a/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
+++ b/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.18.1" />
-    <PackageReference Include="Grpc" Version="2.41.0" />
+    <!--<PackageReference Include="Grpc" Version="2.41.0" />-->
     <!-- Grpc.Tools is build-only dependency, the resulting package doesn't depend on it -->
     <PackageReference Include="Grpc.Tools" Version="2.41.0" PrivateAssets="All" />
     <PackageReference Include="Grpc.Net.Client" Version="2.40.0" />

--- a/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
+++ b/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\Common.csproj.include" />
-
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <Company>Google Inc.</Company>
     <Authors>Google Inc.</Authors>
     <Description>Extension supporting Google Cloud Platform specific features for gRPC.</Description>
@@ -18,15 +16,6 @@
 - Upgrade gRPC version to v2.25.0</PackageReleaseNotes>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../keys/Grpc.Gcp.snk</AssemblyOriginatorKeyFile>
-    <DelaySign></DelaySign>
-  </PropertyGroup>
-
-  <!--
-    - Override target frameworks on non-Windows to just .NET Standard
-    -->
-  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFrameworks>netstandard1.5</TargetFrameworks>
-    <PublicSign>true</PublicSign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
+++ b/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
@@ -19,9 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
-    <PackageReference Include="Grpc" Version="2.25.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.25.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.18.1" />
+    <PackageReference Include="Grpc" Version="2.41.0" />
+    <!-- Grpc.Tools is build-only dependency, the resulting package doesn't depend on it -->
+    <PackageReference Include="Grpc.Tools" Version="2.41.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
   </ItemGroup>
 
 </Project>

--- a/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
+++ b/Grpc.Gcp/Grpc.Gcp/Grpc.Gcp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Company>Google Inc.</Company>
     <Authors>Google Inc.</Authors>
     <Description>Extension supporting Google Cloud Platform specific features for gRPC.</Description>


### PR DESCRIPTION
This is a very rough prototype, but it seems that after some cleanup, most of the logic can be simply reused.

With this change, one can build Grpc.Gcp against Grpc.Net.Client (no Grpc.Core required).

The GcpCallInvoker instance can be created from  `ChannelRefFactoryGrpcDotnet` and `ApiConfig` (we can come up with better API, but this does the job).